### PR TITLE
Replace npm ci with pnpm install --frozen-lockfile to fix release step

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -55,7 +55,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: npm ci
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - run: pnpm install --frozen-lockfile
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |


### PR DESCRIPTION
@mansona Sorry about that, missed one lingering `npm` command on the release step. This should do it